### PR TITLE
get list of only real "teams" not also groups and other stuff

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -65,7 +65,7 @@ export async function getFileList(accessToken, file_path, daysBefore = daysBefor
 }
 
 export async function getTeamList(accessToken) {
-    return getGraphResponse(accessToken, "https://graph.microsoft.com/v1.0/teams")
+    return getGraphResponse(accessToken, "https://graph.microsoft.com/v1.0/me/joinedTeams")
 }
 
 export function getStartFromDateStr(daysBefore = daysBefore_global) {


### PR DESCRIPTION
The `me/joinedTeams` Microsoft Graph API endpoint appears to be a better choice for getting actual Teams that a user has access to because it doesn't also return 365 groups and SP groups like the existing `teams` endpoint does.

---

`https://graph.microsoft.com/v1.0/me/joinedTeams`
https://learn.microsoft.com/en-us/graph/api/user-list-joinedteams?view=graph-rest-1.0&tabs=http
> Get the teams in Microsoft Teams that the user is a direct member of.
> Note: This API doesn't return the host team of the shared channel that the user is a direct member of. Use the List associated teams API, to retrieve the host teams of the shared channels that the user has access to.
> 

---

`https://graph.microsoft.com/v1.0/teams`
https://learn.microsoft.com/en-us/graph/api/teams-list?view=graph-rest-1.0&tabs=http
> List all teams in an organization.

---

`https://graph.microsoft.com/v1.0/users/{user-id}/teamwork/associatedTeams`
https://learn.microsoft.com/en-us/graph/api/associatedteaminfo-list?view=graph-rest-1.0&tabs=http
> Get the list of teams in Microsoft Teams that a user is associated with. Currently, a user can be associated with a team in two different ways:
> A user can be a direct member of a team.
> A user can be a member of a shared channel that is hosted inside a team.

---

`https://graph.microsoft.com/v1.0/groups` (with scope "Group.Read.All")
https://learn.microsoft.com/en-us/graph/api/resources/group?view=graph-rest-1.0
https://learn.microsoft.com/en-us/graph/api/resources/teams-api-overview?view=graph-rest-1.0
> Microsoft 365 (unified) groups: GET /groups?$filter=groupTypes/any(c:c+eq+'Unified')
> Security groups: GET /groups?$filter=mailEnabled eq false&securityEnabled eq true