### PR TITLE
functionize `getFilesContent()`

### DIFF
--- a/src/components/ChatCompletion.jsx
+++ b/src/components/ChatCompletion.jsx
@@ -4,7 +4,7 @@ import { useMsal } from '@azure/msal-react';
 import { AzureOpenAI } from 'openai';
 
 import { loginRequest } from '../authConfig';
-import { getEmail, getFileList, getChatMessages, getChannelMessageList } from '../graph';
+import { getEmail, getFilesContent, getChatMessages, getChannelMessageList } from '../graph';
 import { ChatCompletionData } from '../dataview';
 import { systemPrompt, userPrompt } from '../values';
 
@@ -58,30 +58,10 @@ export const ChatCompletion = () => {
 
                     const email = getEmail(token);
 
-                    const file_content = getFileList(token, file_path)
-                        .then((file_list) => {
-                            const urls = file_list.map(d => d["@microsoft.graph.downloadUrl"]);
-
-                            async function get_content(url, callback) {
-                               const config = {
-                                    newlineDelimiter: " ",
-                                    ignoreNotes: true
-                                }
-                                const response = await fetch(url);
-                                const arrayBuffer = await response.arrayBuffer();
-                                const result = await officeParser.parseOfficeAsync(arrayBuffer, config);
-                                return(result);
-                            }
-
-                            return Promise.all(urls.map(a => get_content(a)))
-                                .then((text) => {
-                                    const result = file_list.map((e,i) => ({
-                                        ...e,
-                                        text: text[i]
-                                    }));
-                                    return(result);
-                                })
-                        });
+                    let file_content = Promise.resolve([]);
+                    if (file_path !== null && file_path != "") {
+                        file_content = getFilesContent(token, file_path);
+                    }
 
                     let chat_msgs = Promise.resolve({value:[]});
                     if (selected_chats !== null) {

--- a/src/components/ChatCompletion.jsx
+++ b/src/components/ChatCompletion.jsx
@@ -52,7 +52,7 @@ export const ChatCompletion = () => {
                 .then((response) => {
                     const token = response.accessToken;
 
-                    const file_path = document.getElementById("file_path").value;
+                    const file_paths = Array.from(document.querySelectorAll("#file_path"), e => e.value);
                     const selected_chats = document.querySelector('input[name="chat_id"]:checked');
                     const selected_channels = document.querySelector('input[name="teamchannel_id"]:checked');
 
@@ -60,7 +60,7 @@ export const ChatCompletion = () => {
 
                     let file_content = Promise.resolve([]);
                     if (file_path !== null && file_path != "") {
-                        file_content = getFilesContent(token, file_path);
+                        file_content = getFilesContent(token, file_paths);
                     }
 
                     let chat_msgs = Promise.resolve({value:[]});
@@ -142,8 +142,10 @@ export const ChatCompletion = () => {
             ) : (
                 <br/>
             )}
-            <h5 className="filepath_head">File Path</h5>
+            <h5 className="filepath_head">File Paths</h5>
             <input id="file_path" defaultValue="test_folder" />
+            <br />
+            <input id="file_path" defaultValue="test_folder2" />
             <br/>
             <br/>
         </>

--- a/src/components/FilesContent.jsx
+++ b/src/components/FilesContent.jsx
@@ -11,7 +11,7 @@ export const FilesContent = () => {
     const [graphData, setGraphData] = useState(null);
 
     function RequestData(formData) {
-        const file_path = document.getElementById("filescontent_file_path").value;
+        const file_paths = Array.from(document.querySelectorAll("#filescontent_file_path"), e => e.value);
         const url = "https://graph.microsoft.com/v1.0/me/drive/root:/" + file_path + ":/children";
 
         instance
@@ -21,7 +21,7 @@ export const FilesContent = () => {
             })
             .then((response) => {
                 const token = response.accessToken;
-                getFilesContent(token, file_path)
+                getFilesContent(token, file_paths)
                     .then(result => setGraphData(result));
             });
     }
@@ -29,12 +29,17 @@ export const FilesContent = () => {
     return (
         <>
             <h5 className="api">Files Content</h5>
-            <label>
-                File Path: <input id="filescontent_file_path" />
-            </label>
             <Button variant="secondary"  onClick={RequestData}>
                 Get Files Content
             </Button>
+            <br />
+            <label>
+                File Paths: <input id="filescontent_file_path" />
+            </label>
+            <br />
+            <label>
+                File Paths: <input id="filescontent_file_path" />
+            </label>
             {graphData ? (
                 <FilesContentData graphData={graphData} />
             ) : (

--- a/src/components/FilesContent.jsx
+++ b/src/components/FilesContent.jsx
@@ -34,11 +34,11 @@ export const FilesContent = () => {
             </Button>
             <br />
             <label>
-                File Paths: <input id="filescontent_file_path" />
+                File Path: <input id="filescontent_file_path" />
             </label>
             <br />
             <label>
-                File Paths: <input id="filescontent_file_path" />
+                File Path: <input id="filescontent_file_path" />
             </label>
             {graphData ? (
                 <FilesContentData graphData={graphData} />

--- a/src/components/FilesContent.jsx
+++ b/src/components/FilesContent.jsx
@@ -21,33 +21,8 @@ export const FilesContent = () => {
             })
             .then((response) => {
                 const token = response.accessToken;
-                getFileList(token, file_path)
-                    .then((file_list) => {
-                        const urls = file_list.map(d => d["@microsoft.graph.downloadUrl"]);
-
-                        async function get_content(url, callback) {
-                           const config = {
-                                newlineDelimiter: " ",
-                                ignoreNotes: true
-                            }
-                            const response = await fetch(url);
-                            const arrayBuffer = await response.arrayBuffer();
-                            const result = await officeParser.parseOfficeAsync(arrayBuffer, config);
-                            return(result);
-                        }
-
-                        Promise.all(urls.map(a => get_content(a)))
-                            .then((text) => {
-                                const result = file_list.map((e,i) => ({
-                                    ...e,
-                                    text: text[i]
-                                }));
-                                setGraphData(result);
-                            })
-
-                    })
-
-
+                getFilesContent(token, file_path)
+                    .then(result => setGraphData(result));
             });
     }
 

--- a/src/components/FilesContent.jsx
+++ b/src/components/FilesContent.jsx
@@ -3,7 +3,7 @@ import Button from 'react-bootstrap/Button';
 import { useMsal } from '@azure/msal-react';
 
 import { loginRequest } from '../authConfig';
-import { getFileList } from '../graph';
+import { getFilesContent } from '../graph';
 import { FilesContentData } from '../dataview';
 
 export const FilesContent = () => {

--- a/src/components/FilesList.jsx
+++ b/src/components/FilesList.jsx
@@ -3,7 +3,7 @@ import Button from 'react-bootstrap/Button';
 import { useMsal } from '@azure/msal-react';
 
 import { loginRequest } from '../authConfig';
-import { getFileList } from '../graph';
+import { getFileListFromMultiplePaths } from '../graph';
 import { FilesListData } from '../dataview';
 
 export const FilesList = () => {
@@ -11,7 +11,7 @@ export const FilesList = () => {
     const [graphData, setGraphData] = useState(null);
 
     function RequestData(formData) {
-        const file_path = document.getElementById("fileslist_file_path").value;
+        const file_paths = Array.from(document.querySelectorAll("#fileslist_file_path"), e => e.value);
 
         instance
             .acquireTokenSilent({
@@ -20,7 +20,7 @@ export const FilesList = () => {
             })
             .then((response) => {
                 const token = response.accessToken;
-                getFileList(token, file_path)
+                getFileListFromMultiplePaths(token, file_paths)
                     .then((result) => {
                         setGraphData(result);
                     })
@@ -30,12 +30,17 @@ export const FilesList = () => {
     return (
         <>
             <h5 className="api">Files List</h5>
-            <label>
-                File Path: <input id="fileslist_file_path" />
-            </label>
             <Button variant="secondary" onClick={RequestData}>
                 Get Files List
             </Button>
+            <br />
+            <label>
+                File Path: <input id="fileslist_file_path" />
+            </label>
+            <br />
+            <label>
+                File Path: <input id="fileslist_file_path" />
+            </label>
             {graphData ? (
                 <FilesListData graphData={graphData} />
             ) : (

--- a/src/graph.js
+++ b/src/graph.js
@@ -84,6 +84,15 @@ export async function getFilesContent(accessToken, file_path, daysBefore = daysB
     const file_list = await getFileList(accessToken, file_path, daysBefore);
 
     // filter to files that officeParser can parse
+    // https://github.com/harshankur/officeParser?tab=readme-ov-file#supported-file-types
+    // https://learn.microsoft.com/en-us/azure/communication-services/concepts/email/email-attachment-allowed-mime-types#attachment-types
+    const mimeTypes = new Set([
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/pdf"
+    ]);
+    file_list = file_list.filter(e => mimeTypes.has(e.file.mimeType));
 
     const urls = file_list.map(d => d["@microsoft.graph.downloadUrl"]);
 

--- a/src/graph.js
+++ b/src/graph.js
@@ -55,13 +55,47 @@ export async function getChatMessages(accessToken, chat_id, daysBefore = daysBef
 }
 
 export async function getFileList(accessToken, file_path, daysBefore = daysBefore_global) {
-    const url = "https://graph.microsoft.com/v1.0/me/drive/root:/" + file_path + ":/children";
-    const dir_list = await getGraphResponse(accessToken, url);
+    const api_url =
+        "https://graph.microsoft.com/v1.0/me/drive/root:/" +
+        file_path +
+        ":/children";
+    const dir_list = await getGraphResponse(accessToken, api_url);
+
     const recent_dir_list = dir_list.value
         .filter(e => e.lastModifiedDateTime > getStartFromDateStr(daysBefore));
-    const file_list = recent_dir_list.filter(e => !e.folder);
+    const file_list = recent_dir_list.filter(e => e.file);
     const subfolder_list = recent_dir_list.filter(e => e.folder);
+
     return file_list;
+}
+
+export async function getFileContent(accessToken, file_url) {
+    const config = {
+        newlineDelimiter: " ",
+        ignoreNotes: true
+    };
+    const response = await fetch(file_url);
+    const arrayBuffer = await response.arrayBuffer();
+    const result = await officeParser.parseOfficeAsync(arrayBuffer, config);
+    return result;
+}
+
+export async function getFilesContent(accessToken, file_path, daysBefore = daysBefore_global) {
+    const file_list = await getFileList(accessToken, file_path, daysBefore);
+
+    // filter to files that officeParser can parse
+
+    const urls = file_list.map(d => d["@microsoft.graph.downloadUrl"]);
+
+    const result = await Promise.all(urls.map(a => getFileContent(accessToken, a)))
+        .then((text) => {
+            return file_list.map((e, i) => ({
+                ...e,
+                text: text[i]
+            }));
+        });
+
+    return result;
 }
 
 export async function getTeamList(accessToken) {

--- a/src/graph.js
+++ b/src/graph.js
@@ -81,7 +81,7 @@ export async function getFileContent(file_url) {
 }
 
 export async function getFilesContent(accessToken, file_path, daysBefore = daysBefore_global) {
-    const file_list = await getFileList(accessToken, file_path, daysBefore);
+    let file_list = await getFileList(accessToken, file_path, daysBefore);
 
     // filter to files that officeParser can parse
     // https://github.com/harshankur/officeParser?tab=readme-ov-file#supported-file-types

--- a/src/graph.js
+++ b/src/graph.js
@@ -69,7 +69,7 @@ export async function getFileList(accessToken, file_path, daysBefore = daysBefor
     return file_list;
 }
 
-export async function getFileContent(accessToken, file_url) {
+export async function getFileContent(file_url) {
     const config = {
         newlineDelimiter: " ",
         ignoreNotes: true
@@ -87,7 +87,7 @@ export async function getFilesContent(accessToken, file_path, daysBefore = daysB
 
     const urls = file_list.map(d => d["@microsoft.graph.downloadUrl"]);
 
-    const result = await Promise.all(urls.map(a => getFileContent(accessToken, a)))
+    const result = await Promise.all(urls.map(a => getFileContent(a)))
         .then((text) => {
             return file_list.map((e, i) => ({
                 ...e,

--- a/src/graph.js
+++ b/src/graph.js
@@ -69,6 +69,20 @@ export async function getFileList(accessToken, file_path, daysBefore = daysBefor
     return file_list;
 }
 
+export async function getFileListFromMultiplePaths(accessToken, file_paths, daysBefore = daysBefore_global) {
+  file_paths = file_paths.filter(e => e); // remove null, undefined, and ""
+
+  const file_paths_uniq = [...new Set(file_paths)];
+
+  const filelists_promise = file_paths_uniq
+  .map(file_path => getFileList(accessToken, file_path, daysBefore));
+
+  let filelists = await Promise.all(filelists_promise);
+  filelists = filelists.flat();
+
+  return filelists;
+}
+
 export async function getFileContent(file_url) {
     const config = {
         newlineDelimiter: " ",
@@ -80,8 +94,8 @@ export async function getFileContent(file_url) {
     return result;
 }
 
-export async function getFilesContent(accessToken, file_path, daysBefore = daysBefore_global) {
-    let file_list = await getFileList(accessToken, file_path, daysBefore);
+export async function getFilesContent(accessToken, file_paths, daysBefore = daysBefore_global) {
+    let file_list = await getFileListFromMultiplePaths(accessToken, file_paths, daysBefore);
 
     // filter to files that officeParser can parse
     // https://github.com/harshankur/officeParser?tab=readme-ov-file#supported-file-types


### PR DESCRIPTION
- closes #24
- related #49 

This PR functionizes the `getFilesContent()` process, which then facilitates adding multiple features to the process which are picked up wherever they are used:
- can now handle multiple root paths in an array
- for getting content, filters files to those types that officeparser can parse
- filters out null, blank, and non-unique filepaths

⚠️ Note that for local testing, you have to modify `AZURE_FOUNDRY_KEY` to `VITE_AZURE_FOUNDRY_KEY` in both your `.env` file and in code in the [src/components/ChatCompletion.jsx](https://github.com/RMI/relai/blob/get-group-file-list/src/components/ChatCompletion.jsx#L17) file if you're trying to run a RELAI summary. 